### PR TITLE
Make "prepend" behaviour add the template at byte zero instead of before the node

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,9 @@ module.exports = {
             //If there is no template, then there can be no fix.
             if (!resolvedTemplate) {
               fix = undefined;
-              //If it has no header comment or onNonMatchingHeader is set to prepend, prepend to the topNode
+              //If it has no header comment or onNonMatchingHeader is set to prepend, insert at byte 0
             } else if (!hasHeaderComment || (hasHeaderComment && onNonMatchingHeader === "prepend")) {
-              fix = fixer => fixer.insertTextBefore(topNode, resolvedTemplate);
+              fix = fixer => fixer.insertTextBeforeRange([0, 0], resolvedTemplate);
               //replace header comment
             } else if (hasHeaderComment && onNonMatchingHeader === "replace") {
               fix = fixer => fixer.replaceText(topNode, resolvedTemplate);


### PR DESCRIPTION
This is related to #3.

My use case is wanting to have **no** blank lines at the beginning of the file before the notice template.

In order to achieve this, I create a `RegExp` starting with `^`, like:

```
var copyrightTemplate = fs.readFileSync('bsd-license.txt').toString();
var copyrightMatch = new RegExp( "^" + escapeStringRegexp(copyrightTemplate) );

// ...
	"rules":{
		"notice/notice":["error",{
			"mustMatch": copyrightMatch,
			"template": copyrightTemplate,
		}]
	}
```

If my files start with a few blank lines and then a block comment, then the fix will *prepend* the template to the first node in the AST. Unfortunately, the first node does *not* start at byte 0, so it leaves the blank lines at the beginning intact.

The fix uses `insertTextBeforeRange([0, 0]` to add the template at the very beginning of the file, instead of before the first node.