### PR TITLE
Implement runners

### DIFF
--- a/src/rules/notice.ts
+++ b/src/rules/notice.ts
@@ -2,11 +2,11 @@
  * Copyright (c) 2024, Nick Deis
  */
 
-import { createFixer, createRule, normalizeLineEndings } from "../utils";
+import { ReportFixFunction } from "@typescript-eslint/utils/ts-eslint";
 import { isNumber } from "lodash";
 import metriclcs from "metric-lcs";
-import { ReportFixFunction } from "@typescript-eslint/utils/ts-eslint";
 import { resolveOptions } from "../config";
+import { createFixer, createRule, normalizeLineEndings } from "../utils";
 
 export const noticeRule = createRule({
   meta: {
@@ -27,8 +27,8 @@ export const noticeRule = createRule({
       context.filename,
     );
 
-    const sourceCode = context.sourceCode;
-    const text = sourceCode.text.substring(0, chars);
+    const sourceCode = context.getSourceCode(); // eslint v6/v7 don't have `sourceCode`
+    const text = sourceCode.getText().substring(0, chars);
     const firstComment = sourceCode.getAllComments().at(0);
 
     return {

--- a/tests/eslint-aliases.d.ts
+++ b/tests/eslint-aliases.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2024, Nick Deis
+ */
+
+declare module "eslint6" {
+  export * from "eslint-types6";
+  export { default } from "eslint-types6";
+}
+
+declare module "eslint7" {
+  export * from "eslint-types7";
+  export { default } from "eslint-types7";
+}
+
+declare module "eslint8" {
+  export * from "eslint-types8";
+  export { default } from "eslint-types8";
+}

--- a/tests/rules/notice.test.ts
+++ b/tests/rules/notice.test.ts
@@ -2,10 +2,10 @@
  * Copyright (c) 2024, Nick Deis
  */
 
-import { RuleTester, TestCaseError } from "@typescript-eslint/rule-tester";
-import * as vitest from "vitest";
-import { noticeRule } from "../../src/rules/notice.js";
+import { TestCaseError } from "@typescript-eslint/rule-tester";
 import { DefaultMessages } from "../../src/config/index.js";
+import { noticeRule } from "../../src/rules/notice.js";
+import { runAll } from "../runners.js";
 import { readAndNormalize, templateFile } from "../utils/files.js";
 
 const notExact = `
@@ -80,18 +80,10 @@ function expectMessage(message: string | keyof typeof DefaultMessages): TestCase
   ] as never;
 }
 
-// Map vitest to RuleTester
-RuleTester.afterAll = vitest.afterAll;
-RuleTester.it = vitest.it;
-RuleTester.itOnly = vitest.it.only;
-RuleTester.describe = vitest.describe;
-
-const ruleTester = new RuleTester();
-
 const template = templateFile("basic");
 const mustMatch = /Copyright \(c\) [0-9]{0,4}, Nick Deis/;
 
-ruleTester.run("notice", noticeRule, {
+runAll("notice", noticeRule, {
   invalid: [
     {
       name: "Prepends the template before any code",

--- a/tests/runners.ts
+++ b/tests/runners.ts
@@ -1,33 +1,123 @@
+/**
+ * Copyright (c) 2024, Nick Deis
+ */
+
+import { InvalidTestCase, RuleTester, RunTests, ValidTestCase } from "@typescript-eslint/rule-tester";
+import type { AnyRuleModule } from "@typescript-eslint/utils/ts-eslint";
 import { RuleTester as RuleTester6 } from "eslint6";
 import { RuleTester as RuleTester7 } from "eslint7";
 import { RuleTester as RuleTester8 } from "eslint8";
-import { Rule, RuleTester as RuleTester } from "eslint";
-import type { RuleTester as TRuleTester6, Rule as Rule6 } from "eslint-types6";
-import type { RuleTester as TRuleTester7, Rule as Rule7 } from "eslint-types7";
-import type { RuleTester as TRuleTester8, Rule as Rule8 } from "eslint-types8";
-import { RunTests } from "@typescript-eslint/rule-tester";
+import { omit } from "lodash";
+import * as vitest from "vitest";
+import { describe, it } from "vitest";
 
-const RULE_TESTERS: Record<
-  "6" | "7" | "8" | "9",
-  TRuleTester6 | TRuleTester7 | TRuleTester8 | RuleTester
-> = {
-  "6": new RuleTester6() as TRuleTester6,
-  "7": new RuleTester7() as TRuleTester7,
-  "8": new RuleTester8() as TRuleTester8,
+// We only need to bind for typescript-eslint
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const RULE_TESTERS = {
+  "6": new RuleTester6(),
+  "7": new RuleTester7(),
+  "8": new RuleTester8(),
   "9": new RuleTester(),
-};
+} as const;
 
-export function runAll(
-  ruleName: string,
-  rule:
-    | Rule.RuleModule
-    | Rule6.RuleModule
-    | Rule7.RuleModule
-    | Rule8.RuleModule,
-  test: RunTests<never, readonly unknown[]>
+/**
+ * Seperates the name from a test case.
+ *
+ * See {@link prepareTestCases} for context.
+ *
+ * @remarks
+ * Throws an error if the test case is just a string.
+ * While supported by eslint, it defeats the purpose of
+ * named tests.
+ *
+ * @param testCase The test case to convert.
+ *
+ * @returns An object with the name seperated from the test case.
+ */
+function convertTestCase<T extends ValidTestCase<Options> | InvalidTestCase<never, Options>, Options extends unknown[]>(
+  testCase: T | string,
 ) {
+  if (typeof testCase === "string") {
+    throw new Error(`Invalid test case specified: ${testCase}`);
+  }
+
+  const name = testCase.name ?? "Unnamed test case";
+  return {
+    name,
+    test: omit(testCase, "name"),
+  };
+}
+
+/**
+ * Maps test cases to a variant that can be used for older rule testers.
+ *
+ * @remarks
+ * Older versions of {@link RuleTester} don't have a `name` property.
+ * To circumvent this, without losing test names, we map each test
+ * case to a version without the `name` property, and use a vitest {@link it}
+ * block to specify the name.
+ *
+ * @param test The test case to process.
+ *
+ * @returns A mapped version of runtests from {@link convertTestCase}.
+ */
+function prepareTestCases<T extends readonly unknown[]>(test: RunTests<never, T>) {
+  const valid = test.valid.map(convertTestCase);
+  const invalid = test.invalid.map(convertTestCase);
+
+  return {
+    valid,
+    invalid,
+  };
+}
+
+/**
+ * Runs the tests for an eslint rule against multiple versions of eslint.
+ *
+ * @remarks
+ * Specifically, this runs the rule against versions 6 through 9.
+ *
+ * The tests will run under vitest {@link it} blocks instead of being bundled
+ * together in one {@link RuleTester} run. This works around the fact
+ * that older versions of rule tester don't support test case naming.
+ *
+ * @param ruleName The name of the rule we're testing.
+ * @param rule The rule itself to test.
+ * @param testCase A mapping of test cases to run.
+ */
+export function runAll(ruleName: string, rule: AnyRuleModule, testCase: RunTests<never, readonly unknown[]>) {
   const testers = Object.entries(RULE_TESTERS);
+  const cases = prepareTestCases(testCase);
+
   for (const [version, ruleTester] of testers) {
-    ruleTester.run(ruleName, rule, test);
+    describe(`${ruleName} [v${version}]`, () => {
+      describe("valid", () => {
+        for (const { name, test } of cases.valid) {
+          it(name, () => {
+            // We don't bother casting `rule` to a type-safe variant as eslint-typescript is very opinionated
+            ruleTester.run(ruleName, rule as never, {
+              valid: [test],
+              invalid: [],
+            });
+          });
+        }
+      });
+
+      describe("invalid", () => {
+        for (const { name, test } of cases.invalid) {
+          it(name, () => {
+            ruleTester.run(ruleName, rule as never, {
+              valid: [],
+              // Older test cases could have errors strings, but we can't anymore so it doesn't matter
+              invalid: [test as never],
+            });
+          });
+        }
+      });
+    });
   }
 }


### PR DESCRIPTION
Building off of [this comment](https://github.com/nickdeis/eslint-plugin-notice/pull/30#issuecomment-2531580522),

This finishes the implementation for `runners.ts`, which provides a way to run tests for a rule against older versions of eslint.

@nickdeis Although, are eslint versions 6/7 widely used enough to justify adding support in this manner? I definitely see the merit in supporting version 8, but 6 has been EOL for 4 years and 7 has been EOL for 2 years. 